### PR TITLE
Add `%define _binary_payload w2.xzdio` for compatibility with SailfishOS < 4.4

### DIFF
--- a/rpm/harbour-dwd.spec
+++ b/rpm/harbour-dwd.spec
@@ -7,7 +7,7 @@ Name:       harbour-dwd
 
 # >> macros
 # << macros
-
+%define _binary_payload w2.xzdio
 %{!?qtc_qmake:%define qtc_qmake %qmake}
 %{!?qtc_qmake5:%define qtc_qmake5 %qmake5}
 %{!?qtc_make:%define qtc_make make}


### PR DESCRIPTION
I wonder about the first four (comment) lines of the spec file.  I cannot find the corresponding `yaml` file for Spectacle!?!

* If one exists and is used, please ignore this PR and add in its `Macros:` section the line:
`- _binary_payload;w2.xzdio`

* If it does not exist please consider to remove the (misleading in this case) first four (comment) lines.

<br />
Thanks, HTH & cheers :smiley: